### PR TITLE
Fixing AttributeError

### DIFF
--- a/tpot/builtins/one_hot_encoder.py
+++ b/tpot/builtins/one_hot_encoder.py
@@ -158,7 +158,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         Non-categorical features are always stacked to the right of the matrix.
 
-    dtype : number type, default=np.float
+    dtype : number type, default=np.float64
         Desired dtype of output.
 
     sparse : boolean, default=True
@@ -213,7 +213,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
       encoding of dictionary items or strings.
     """
 
-    def __init__(self, categorical_features='auto', dtype=np.float,
+    def __init__(self, categorical_features='auto', dtype=np.float64,
                  sparse=True, minimum_fraction=None, threshold=10):
         self.categorical_features = categorical_features
         self.dtype = dtype


### PR DESCRIPTION
In Python 3.9.16, it raises AttributeError. So, fix has implemented. Full error is down below: 
AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations